### PR TITLE
Migrate project to the `db-operator` org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For triggering it, change the version of Chart.yaml in the chart directory and m
 
 ## Configuring helm client
 ```
-$ helm repo add kloeckneri https://kloeckner-i.github.io/charts
+$ helm repo add db-operator https://db-operator.github.io/charts
 ```
 Test the helm chart repository
 ```
-$ helm search repo kloeckneri
+$ helm search repo db-operator
 ```

--- a/charts/db-instances/Chart.yaml
+++ b/charts/db-instances/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Database Instances for db operator
 name: db-instances
-version: 1.4.0
+version: 1.4.1

--- a/charts/db-instances/README.md
+++ b/charts/db-instances/README.md
@@ -4,7 +4,7 @@ Create DB Instance resources for is DB Operator
 ## Installing Chart
 To install the chart with the release name my-release:
 ```
-$ helm install --name my-release kloeckneri/db-instances
+$ helm install --name my-release db-operator/db-instances
 ```
 The command deploys DB Operator on Kubernetes with default configuration.
 

--- a/charts/db-instances/templates/dbinstance.yaml
+++ b/charts/db-instances/templates/dbinstance.yaml
@@ -3,7 +3,7 @@
 {{- if .Values.dbinstances }}
 {{- range $name, $value := .Values.dbinstances }}
 ---
-apiVersion: "kci.rocks/v1beta1"
+apiVersion: "kinda.rocks/v1beta1"
 kind: "DbInstance"
 metadata:
   name: {{ $name }}

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -5,4 +5,4 @@ kubeVersion: ">= 1.21-prerelease"
 appVersion: "1.10.0"
 description: A Database Operator
 name: db-operator
-version: 1.7.0
+version: 1.7.1

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 ## All supported k8s versions are in the test: https://github.com/db-operator/db-operator/blob/master/.github/workflows/build-and-test.yaml
 kubeVersion: ">= 1.21-prerelease"
-appVersion: "1.10.0"
+appVersion: "1.10.1"
 description: A Database Operator
 name: db-operator
 version: 1.7.1

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 type: application
-## All supported k8s versions are in the test: https://github.com/kloeckner-i/db-operator/blob/master/.github/workflows/build-and-test.yaml
+## All supported k8s versions are in the test: https://github.com/db-operator/db-operator/blob/master/.github/workflows/build-and-test.yaml
 kubeVersion: ">= 1.21-prerelease"
 appVersion: "1.10.0"
 description: A Database Operator

--- a/charts/db-operator/README.md
+++ b/charts/db-operator/README.md
@@ -8,7 +8,7 @@ For example:
 
 ```BASH
 $ helm upgrade my-release .
-Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: CustomResourceDefinition "databases.kci.rocks" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "my-release"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "default"
+Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: CustomResourceDefinition "databases.kinda.rocks" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "my-release"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "default"
 ```
 
 So you should add following metadata:

--- a/charts/db-operator/README.md
+++ b/charts/db-operator/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the db-operator chart a
 | `affinity`            | Node affinity for pod assignment      | `{}`                      |
 | `annotations`         | Annotations to add to the db-operator pod | `{}`                  |
 | `podLabels`           | Labels to add to the db-operator pod  | `{}`                      |
-| `config.instance.google.proxy.image` | Container image of db-auth-gateway | `db-operator/db-auth-gateway:0.1.7` |
+| `config.instance.google.proxy.image` | Container image of db-auth-gateway | `ghcr.io/db-operator/db-auth-gateway:v0.1.10` |
 | `config.instance.google.proxy.nodeSelector` | Node labels for google cloud proxy pod assignment | `{}` |
 | `config.backup.nodeSelector` | Node labels for backup pod assignment | `{}` |
 | `config.backup.resources` | Resource configuration for running backup container same as https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits | `{}` |

--- a/charts/db-operator/README.md
+++ b/charts/db-operator/README.md
@@ -24,7 +24,7 @@ metadata:
 ## Installing Chart
 To install the chart with the release name my-release:
 ```
-$ helm install --name my-release kloeckneri/db-operator
+$ helm install --name my-release db-operator/db-operator
 ```
 The command deploys DB Operator on Kubernetes with default configuration. For the configuration options see details [Parameters](#Parameters)
 
@@ -41,7 +41,7 @@ The following table lists the configurable parameters of the db-operator chart a
 | Parameter             | Description                           | Default                   |
 |-------------------    |-----------------------                |---------------            |
 | `appVersion`          | Application Version (DB Operator)     | TODO                      |
-| `image.repository`    | Container image name                  | `kloeckneri/db-operator`  |
+| `image.repository`    | Container image name                  | `db-operator/db-operator`  |
 | `image.tag`           | Container image tag                   | `latest`                  |
 | `image.pullPolicy`    | Container pull policy                 | `Always`                  |
 | `imagePullSecrets`    | Reference to secret to be used when pulling images | "" |
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the db-operator chart a
 | `affinity`            | Node affinity for pod assignment      | `{}`                      |
 | `annotations`         | Annotations to add to the db-operator pod | `{}`                  |
 | `podLabels`           | Labels to add to the db-operator pod  | `{}`                      |
-| `config.instance.google.proxy.image` | Container image of db-auth-gateway | `kloeckneri/db-auth-gateway:0.1.7` |
+| `config.instance.google.proxy.image` | Container image of db-auth-gateway | `db-operator/db-auth-gateway:0.1.7` |
 | `config.instance.google.proxy.nodeSelector` | Node labels for google cloud proxy pod assignment | `{}` |
 | `config.backup.nodeSelector` | Node labels for backup pod assignment | `{}` |
 | `config.backup.resources` | Resource configuration for running backup container same as https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits | `{}` |

--- a/charts/db-operator/ci/ci-2-values.yaml
+++ b/charts/db-operator/ci/ci-2-values.yaml
@@ -39,7 +39,7 @@ config:
     google:
       proxy:
         nodeSelector: {}
-        image: db-operator/db-auth-gateway:0.1.7
+        image: ghcr.io/db-operator/db-auth-gateway:latest
         metricsPort: 9090
     generic: {}
     percona:

--- a/charts/db-operator/ci/ci-2-values.yaml
+++ b/charts/db-operator/ci/ci-2-values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/kloeckner-i/db-operator
+  repository: ghcr.io/db-operator/db-operator
   pullPolicy: Always
 
 reconcileInterval: "60"
@@ -39,7 +39,7 @@ config:
     google:
       proxy:
         nodeSelector: {}
-        image: kloeckneri/db-auth-gateway:0.1.7
+        image: db-operator/db-auth-gateway:0.1.7
         metricsPort: 9090
     generic: {}
     percona:

--- a/charts/db-operator/ci/ci-3-values.yaml
+++ b/charts/db-operator/ci/ci-3-values.yaml
@@ -51,7 +51,7 @@ config:
       proxy:
         nodeSelector:
           nodetype: database
-        image: db-operator/db-auth-gateway:0.1.7
+        image: ghcr.io/db-operator/db-auth-gateway:latest
         metricsPort: 9090
     generic: {}
     percona:

--- a/charts/db-operator/ci/ci-3-values.yaml
+++ b/charts/db-operator/ci/ci-3-values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/kloeckner-i/db-operator
+  repository: ghcr.io/db-operator/db-operator
   pullPolicy: Always
 
 reconcileInterval: "60"
@@ -51,7 +51,7 @@ config:
       proxy:
         nodeSelector:
           nodetype: database
-        image: kloeckneri/db-auth-gateway:0.1.7
+        image: db-operator/db-auth-gateway:0.1.7
         metricsPort: 9090
     generic: {}
     percona:

--- a/charts/db-operator/ci/ci-4-values.yaml
+++ b/charts/db-operator/ci/ci-4-values.yaml
@@ -38,7 +38,7 @@ config:
     google:
       proxy:
         nodeSelector: {}
-        image: db-operator/db-auth-gateway:0.1.7
+        image: ghcr.io/db-operator/db-auth-gateway:latest
         metricsPort: 9090
     generic: {}
     percona:

--- a/charts/db-operator/ci/ci-4-values.yaml
+++ b/charts/db-operator/ci/ci-4-values.yaml
@@ -38,7 +38,7 @@ config:
     google:
       proxy:
         nodeSelector: {}
-        image: kloeckneri/db-auth-gateway:0.1.7
+        image: db-operator/db-auth-gateway:0.1.7
         metricsPort: 9090
     generic: {}
     percona:

--- a/charts/db-operator/templates/crds/kci.rocks_databases.yaml
+++ b/charts/db-operator/templates/crds/kci.rocks_databases.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   creationTimestamp: null
-  name: databases.kci.rocks
+  name: databases.kinda.rocks
 spec:
   conversion:
     strategy: Webhook
@@ -30,7 +30,7 @@ spec:
       conversionReviewVersions:
         - v1alpha1
         - v1beta1
-  group: kci.rocks
+  group: kinda.rocks
   names:
     kind: Database
     listKind: DatabaseList

--- a/charts/db-operator/templates/crds/kci.rocks_dbinstances.yaml
+++ b/charts/db-operator/templates/crds/kci.rocks_dbinstances.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- with .Values.crds.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  name: dbinstances.kci.rocks
+  name: dbinstances.kinda.rocks
 spec:
   conversion:
     strategy: Webhook
@@ -28,7 +28,7 @@ spec:
       conversionReviewVersions:
         - v1alpha1
         - v1beta1
-  group: kci.rocks
+  group: kinda.rocks
   names:
     kind: DbInstance
     listKind: DbInstanceList

--- a/charts/db-operator/templates/rbac.yaml
+++ b/charts/db-operator/templates/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
 - apiGroups:
-  - kci.rocks
+  - kinda.rocks
   resources:
   - "*"
   verbs:

--- a/charts/db-operator/templates/webhook/mutating_webhook.yaml
+++ b/charts/db-operator/templates/webhook/mutating_webhook.yaml
@@ -23,7 +23,7 @@ webhooks:
   name: mdatabase.kb.io
   rules:
   - apiGroups:
-    - kci.rocks
+    - kinda.rocks
     apiVersions:
     - v1beta1
     operations:
@@ -43,7 +43,7 @@ webhooks:
   name: mdbinstance.kb.io
   rules:
   - apiGroups:
-    - kci.rocks
+    - kinda.rocks
     apiVersions:
     - v1beta1
     operations:

--- a/charts/db-operator/templates/webhook/mutating_webhook.yaml
+++ b/charts/db-operator/templates/webhook/mutating_webhook.yaml
@@ -18,7 +18,7 @@ webhooks:
     service:
       name: {{ .Values.webhook.serviceName }}
       namespace: {{ .Release.Namespace }}
-      path: /mutate-kci-rocks-v1beta1-database
+      path: /mutate-kinda-rocks-v1beta1-database
   failurePolicy: Fail
   name: mdatabase.kb.io
   rules:
@@ -38,7 +38,7 @@ webhooks:
     service:
       name: {{ .Values.webhook.serviceName }}
       namespace: {{ .Release.Namespace }}
-      path: /mutate-kci-rocks-v1beta1-dbinstance
+      path: /mutate-kinda-rocks-v1beta1-dbinstance
   failurePolicy: Fail
   name: mdbinstance.kb.io
   rules:

--- a/charts/db-operator/templates/webhook/validation_webhook.yaml
+++ b/charts/db-operator/templates/webhook/validation_webhook.yaml
@@ -18,7 +18,7 @@ webhooks:
     service:
       name: {{ .Values.webhook.serviceName }}
       namespace: {{ .Release.Namespace }}
-      path: /validate-kci-rocks-v1beta1-database
+      path: /validate-kinda-rocks-v1beta1-database
   failurePolicy: Fail
   name: vdatabase.kb.io
   rules:
@@ -38,7 +38,7 @@ webhooks:
     service:
       name: {{ .Values.webhook.serviceName }}
       namespace: {{ .Release.Namespace }}
-      path: /validate-kci-rocks-v1beta1-dbinstance
+      path: /validate-kinda-rocks-v1beta1-dbinstance
   failurePolicy: Fail
   name: vdbinstance.kb.io
   rules:

--- a/charts/db-operator/templates/webhook/validation_webhook.yaml
+++ b/charts/db-operator/templates/webhook/validation_webhook.yaml
@@ -23,7 +23,7 @@ webhooks:
   name: vdatabase.kb.io
   rules:
   - apiGroups:
-    - kci.rocks
+    - kinda.rocks
     apiVersions:
     - v1beta1
     operations:
@@ -43,7 +43,7 @@ webhooks:
   name: vdbinstance.kb.io
   rules:
   - apiGroups:
-    - kci.rocks
+    - kinda.rocks
     apiVersions:
     - v1beta1
     operations:

--- a/charts/db-operator/values-stanley.yaml
+++ b/charts/db-operator/values-stanley.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: registry.kci.rocks/devops/db-operator
+  repository: registry.kinda.rocks/devops/db-operator
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/charts/db-operator/values.yaml
+++ b/charts/db-operator/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: ""
 
 image:
-  repository: ghcr.io/kloeckner-i/db-operator
+  repository: ghcr.io/db-operator/db-operator
   pullPolicy: Always
   logLevel: info
 
@@ -70,7 +70,7 @@ config:
     google:
       proxy:
         nodeSelector: {}
-        image: kloeckneri/db-auth-gateway:0.1.7
+        image: db-operator/db-auth-gateway:0.1.7
         metricsPort: 9090
     generic: {}
     percona:

--- a/charts/db-operator/values.yaml
+++ b/charts/db-operator/values.yaml
@@ -70,7 +70,7 @@ config:
     google:
       proxy:
         nodeSelector: {}
-        image: db-operator/db-auth-gateway:0.1.7
+        image: ghcr.io/db-operator/db-auth-gateway:v0.1.10
         metricsPort: 9090
     generic: {}
     percona:

--- a/tests/db-operator/mock-googleapi/templates/api.yaml
+++ b/tests/db-operator/mock-googleapi/templates/api.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: ghcr.io/kloeckner-i/cloudish-sql:v1.0.0
+          image: ghcr.io/db-operator/cloudish-sql:v1.0.0
           ports:
           - containerPort: 8080
             name: http

--- a/tests/db-operator/mock-googleapi/templates/api.yaml
+++ b/tests/db-operator/mock-googleapi/templates/api.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: ghcr.io/db-operator/cloudish-sql:v1.0.0
+          image: ghcr.io/db-operator/cloudish-sql:v1.0.1
           ports:
           - containerPort: 8080
             name: http

--- a/tests/db-operator/mysql-generic/templates/db.yaml
+++ b/tests/db-operator/mysql-generic/templates/db.yaml
@@ -1,4 +1,4 @@
-apiVersion: "kci.rocks/v1beta1"
+apiVersion: "kinda.rocks/v1beta1"
 kind: "Database"
 metadata:
   name: {{ .Values.db.name }}

--- a/tests/db-operator/mysql-generic/templates/instance.yaml
+++ b/tests/db-operator/mysql-generic/templates/instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kci.rocks/v1beta1
+apiVersion: kinda.rocks/v1beta1
 kind: DbInstance
 metadata:
   name: {{ .Values.instance.name }}

--- a/tests/db-operator/postgres-generic/templates/db.yaml
+++ b/tests/db-operator/postgres-generic/templates/db.yaml
@@ -1,4 +1,4 @@
-apiVersion: "kci.rocks/v1beta1"
+apiVersion: "kinda.rocks/v1beta1"
 kind: "Database"
 metadata:
   name: pg-generic-db

--- a/tests/db-operator/postgres-generic/templates/instance.yaml
+++ b/tests/db-operator/postgres-generic/templates/instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kci.rocks/v1beta1
+apiVersion: kinda.rocks/v1beta1
 kind: DbInstance
 metadata:
   name: pg-generic-instance

--- a/tests/db-operator/postgres-gsql/templates/instance.yaml
+++ b/tests/db-operator/postgres-gsql/templates/instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kci.rocks/v1beta1
+apiVersion: kinda.rocks/v1beta1
 kind: DbInstance
 metadata:
   name: pg-gsql-instance


### PR DESCRIPTION
Note: Fur backups old `dump` images are used, because yet there is no Action to push them to ghcr, once they are migrated from dockerhub, it should be updated here as well