### PR TITLE
fix(db-operator): Now db-instance is guarded by if condition as well

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -5,4 +5,4 @@ kubeVersion: ">= 1.21-prerelease"
 appVersion: "1.11.0"
 description: A Database Operator
 name: db-operator
-version: 1.8.0
+version: 1.8.1

--- a/charts/db-operator/templates/crds/kci.rocks_dbinstances.yaml
+++ b/charts/db-operator/templates/crds/kci.rocks_dbinstances.yaml
@@ -379,4 +379,4 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- if .Values.crds.install }}
+{{- end }}

--- a/charts/db-operator/templates/crds/kci.rocks_dbinstances.yaml
+++ b/charts/db-operator/templates/crds/kci.rocks_dbinstances.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crds.install }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -378,3 +379,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- if .Values.crds.install }}


### PR DESCRIPTION
It used to ignore the `crds.install` thing. not it shouldn't anymore