### PR TITLE
fix: Configure the dbuser webhook with values

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 name: db-operator
-version: 1.10.0
+version: 1.10.1
 # ---------------------------------------------------------------------------------
 # -- All supported k8s versions are in the test:
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml

--- a/charts/db-operator/templates/webhook/validation_webhook.yaml
+++ b/charts/db-operator/templates/webhook/validation_webhook.yaml
@@ -57,8 +57,8 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
+      name: {{ .Values.webhook.serviceName }}
+      namespace: {{ .Release.Namespace }}
       path: /validate-kinda-rocks-v1beta1-dbuser
   failurePolicy: Fail
   name: vdbuser.kb.io


### PR DESCRIPTION
Name and namespace were hardcoded and so the the webhook servcice couldn't be reached when one tries to apply dbuser manifests