### PR TITLE
docs: How to upgrade db-operator to 1.11.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,16 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.0
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs helm --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --validate-maintainers=false --target-branch main
 
   test-values:

--- a/charts/db-operator/README.md
+++ b/charts/db-operator/README.md
@@ -105,7 +105,22 @@ If you use webhooks, you also might need to have cert-manager
 
 ## Upgrading
 
-If there is an breaking change, or something that might make the upgrade complcated, it should be decsribed here
+If there is an breaking change, or something that might make the upgrade complicated, it should be described here
+
+<details>
+  <summary>To `v1.11.0`</summary>
+Additional selectors were added to the default templates in an attempt to follow the same labelling scheme everywhere, but since selectors are immutable, the upgrade will require removing of the db-operator deployment.
+
+```bash
+$ kubectl get deploy
+NAME          READY   UP-TO-DATE   AVAILABLE   AGE
+db-operator   1/1     1            1           22s
+$ kubectl delete deploy db-operator
+deployment.apps "db-operator" deleted
+$ helm upgrade db-operator db-operator/db-operator --version 1.11.0
+```
+
+</details>
 
 <details>
   <summary>To `v1.10.0`</summary>


### PR DESCRIPTION
Apparently some breaking changes were made here: https://github.com/db-operator/charts/pull/13, so I've added a note about how to upgrade