### PR TITLE
Set PG_EXPORTER_AUTO_DISCOVERY to true for the pg_exporter

### DIFF
--- a/charts/db-instances/Chart.yaml
+++ b/charts/db-instances/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Database Instances for db operator
 name: db-instances
-version: 2.0.0
+version: 2.1.0

--- a/charts/db-instances/ci/ci-test-service-monitor-values.yaml
+++ b/charts/db-instances/ci/ci-test-service-monitor-values.yaml
@@ -4,6 +4,7 @@ dbinstances:
       enabled: true
     engine: postgres
     monitoring:
+      autodiscovery: true
       enabled: true
     generic:
       host: postgres-instance-postgresql.postgres

--- a/charts/db-instances/templates/postgres_exporter.yaml
+++ b/charts/db-instances/templates/postgres_exporter.yaml
@@ -45,7 +45,7 @@ spec:
         - name: PG_EXPORTER_CONSTANT_LABELS
           value: dbinstance={{ $name }}
         - name: PG_EXPORTER_AUTO_DISCOVERY
-          value: true
+          value: "true"
         image: {{ $exporter.image }}
         imagePullPolicy: Always
         name: exporter

--- a/charts/db-instances/templates/postgres_exporter.yaml
+++ b/charts/db-instances/templates/postgres_exporter.yaml
@@ -44,6 +44,8 @@ spec:
           value: /run/cm/queries/queries.yaml
         - name: PG_EXPORTER_CONSTANT_LABELS
           value: dbinstance={{ $name }}
+        - name: PG_EXPORTER_AUTO_DISCOVERY
+          value: true
         image: {{ $exporter.image }}
         imagePullPolicy: Always
         name: exporter

--- a/charts/db-instances/templates/postgres_exporter.yaml
+++ b/charts/db-instances/templates/postgres_exporter.yaml
@@ -44,8 +44,10 @@ spec:
           value: /run/cm/queries/queries.yaml
         - name: PG_EXPORTER_CONSTANT_LABELS
           value: dbinstance={{ $name }}
+        {{- if $value.monitoring.autodiscovery }}
         - name: PG_EXPORTER_AUTO_DISCOVERY
           value: "true"
+        {{- end }}
         image: {{ $exporter.image }}
         imagePullPolicy: Always
         name: exporter


### PR DESCRIPTION
Since the monitoring is currently enabled on the dbin level, pg_exporter should be able to scrape metrics from all the databases on the instances. 

pg_exporter documentation:
```
--auto-discovery or PG_EXPORTER_AUTO_DISCOVERY will automatically spawn peripheral servers for other databases in the target PostgreSQL server. except for those listed in --exclude-database. (Not implemented yet)
```

I guess that --exclude-database is not implemented, cause it's not that obvious after reading the readme, but I've tried setting this variable in the exporter deployment, and it seemed to work