### PR TITLE
fix(crds/dbuser): Add missing kind property

### DIFF
--- a/charts/db-operator/templates/crds/kinda.rocks_dbuser.yaml
+++ b/charts/db-operator/templates/crds/kinda.rocks_dbuser.yaml
@@ -51,6 +51,7 @@ spec:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
+            kind:
               description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:


### PR DESCRIPTION
This can make the helm-controller in FluxCD fail wihen deploying the CRDs.

It looks like it was removed by mistake in this commit: https://github.com/db-operator/charts/pull/31/files#diff-66962a372944a921e46f640964fc4b5b1a70be183156b5c8e2da609b6700b110L57