### PR TITLE
test: Remove unmaintained k8s versions

### DIFF
--- a/.github/workflows/helm-workflow.yaml
+++ b/.github/workflows/helm-workflow.yaml
@@ -47,9 +47,6 @@ jobs:
     strategy:
       matrix:
         k8s_version:
-          - v1.22.15
-          - v1.23.17
-          - v1.24.15
           - v1.25.11
           - v1.26.6
           - v1.27.3

--- a/.github/workflows/helm-workflow.yaml
+++ b/.github/workflows/helm-workflow.yaml
@@ -51,6 +51,7 @@ jobs:
           - v1.26.6
           - v1.27.3
           - v1.28.0
+          - v1.29.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We shouldn't test unmaintained/usupported versions of k8s - Right?

See
- https://endoflife.date/amazon-eks
- https://endoflife.date/kubernetes