### PR TITLE
 Configure dbinstance via external Secrets/Configmaps

### DIFF
--- a/charts/db-instances/Chart.yaml
+++ b/charts/db-instances/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Database Instances for db operator
 name: db-instances
-version: 2.2.0
+version: 2.3.0

--- a/charts/db-instances/templates/dbinstance.yaml
+++ b/charts/db-instances/templates/dbinstance.yaml
@@ -55,18 +55,18 @@ spec:
     hostFrom:
       kind: ConfigMap
       name: {{ $name }}-config
-      namespace {{ $.Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       key: host
     portFrom:
       kind: ConfigMap
       name: {{ $name }}-config
-      namespace {{ $.Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       key: port
   {{- if $value.generic.publicIp }}
     publicIpFrom:
       kind: ConfigMap
       name: {{ $name }}-config
-      namespace {{ $.Release.Namespace }}
+      namespace: {{ $.Release.Namespace }}
       key: publicIp
   {{- end }}
   {{- if $value.generic.backupHost }}

--- a/charts/db-instances/templates/dbinstance.yaml
+++ b/charts/db-instances/templates/dbinstance.yaml
@@ -52,10 +52,22 @@ spec:
   {{- end }}
   {{- if $value.generic }}
   generic:
-    host: {{ $value.generic.host }}
-    port: {{ $value.generic.port }}
+    hostFrom:
+      kind: ConfigMap
+      name: {{ $name }}-config
+      namespace {{ $.Release.Namespace }}
+      key: host
+    portFrom:
+      kind: ConfigMap
+      name: {{ $name }}-config
+      namespace {{ $.Release.Namespace }}
+      key: port
   {{- if $value.generic.publicIp }}
-    publicIp: {{ $value.generic.publicIp }}
+    publicIpFrom:
+      kind: ConfigMap
+      name: {{ $name }}-config
+      namespace {{ $.Release.Namespace }}
+      key: publicIp
   {{- end }}
   {{- if $value.generic.backupHost }}
     backupHost: {{ $value.generic.backupHost }}
@@ -76,7 +88,6 @@ data:
   password: {{ $value.secrets.adminPassword | b64enc }}
 {{- end }}
 ---
-{{- if $value.google }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -85,8 +96,19 @@ metadata:
   labels:
     {{- include "db-instances.labels" $ | nindent 4 }}
 data:
+{{- if $value.google }}
   config: |
     {{ $value.google.configMap.data | nindent 4 }}
+{{- end }}
+{{- if $value.generic }}
+  host: {{ $value.generic.host }}
+  port: {{ $value.generic.port }}
+  {{- if $value.generic.publicIp }}
+  publicIp: {{ $value.generic.publicIp }}
+  {{- end }}
+{{- end }}
+
+{{- if $value.google }}
 {{- if $value.google.clientSecret }}
 ---
 apiVersion: v1

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 type: application
 name: db-operator
-version: 1.20.0
+version: 1.21.0
 # ---------------------------------------------------------------------------------
 # -- All supported k8s versions are in the test:
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml
 # ---------------------------------------------------------------------------------
 kubeVersion: ">= 1.22-prerelease"
-appVersion: "2.3.0"
+appVersion: "2.4.0"
 description: The DB Operator creates databases and make them available in the cluster via Custom Resource.
 home: https://github.com/db-operator/db-operator
 maintainers:

--- a/charts/db-operator/ci/1-postgresql-from-cm-test-values.yaml
+++ b/charts/db-operator/ci/1-postgresql-from-cm-test-values.yaml
@@ -1,0 +1,13 @@
+reconcileInterval: "10"
+crds:
+  keep: false
+tests:
+  enabled:
+    - postgresql-from-cm
+  postgresql:
+    admin:
+      password: 123123!!
+      user: postgres
+    service:
+      name: postgres-instance-postgresql
+      namespace: databases

--- a/charts/db-operator/templates/NOTES.txt
+++ b/charts/db-operator/templates/NOTES.txt
@@ -22,16 +22,31 @@ The Chart name: {{ .Chart.Name }}.
 The Repo URL: https://db-operator.github.io/charts
 The Release name {{ .Release.Name }}.
 -----------------------------------------------------------------------
-Breaking changes and migration paths
+Breaking changes and migration paths:
 
-{{ .Chart.Version }} is not breaking, you don't have to worry 
+{{ .Chart.Version }} is not breaking, you don't have to worry
+
+Noticeable and important changes:
+
+In {{ .Chart.Version }} google instances are deprecated, they will be
+removed in the next API version (v1beta2)
+
+Please see this issue:
+  https://github.com/db-operator/db-operator/issues/96
+
+We will not remove google instances support within next 6 months after
+{{ .Release.Version }} is released, so users should have enough time
+for migration.
+
+If you have questions, please feel free to create issues here:
+  https://github.com/db-operator/db-operator/issues/96
 
 {{- if not .Values.crds.install }}
 -----------------------------------------------------------------------
 You've chosen not to install CRDs with this release.
 
-We officially do not distribute CRDs outside of this helm chart, so 
-you will have to deal with that on your own. 
+We officially do not distribute CRDs outside of this helm chart, so
+you will have to deal with that on your own.
 
 If it was a mistake, update the values so they contain the following:
 
@@ -41,16 +56,16 @@ If it was a mistake, update the values so they contain the following:
 {{- if not .Values.webhook.enabled }}
 -----------------------------------------------------------------------
 You've chosen not to install and configure the webhook.
-Your "kinda.rocks" manifests won't be validated and converted when 
+Your "kinda.rocks" manifests won't be validated and converted when
 the API version is upgraded.
 
-It's not required by db-operator to work, but if you want to have the 
+It's not required by db-operator to work, but if you want to have the
 webhook in place, you can set ".Values.webhook.enabled" to "true"
 {{- end }}
 
 {{- if has "gsql" .Values.tests.enabled }}
 -----------------------------------------------------------------------
-You seem to have the gsql test set to true, usually, 
+You seem to have the gsql test set to true, usually,
 it shouldn't be done.
 
 Make sure that you want to run tests, and not using this installation
@@ -61,7 +76,7 @@ Or remove 'gsql' '.Values.tests.enabled'
 
 {{- if has "postgresql" .Values.tests.enabled }}
 -----------------------------------------------------------------------
-You seem to have the postgresql test set to true, usually, 
+You seem to have the postgresql test set to true, usually,
 it shouldn't be done.
 
 Make sure that you want to run tests, and not using this installation
@@ -69,13 +84,13 @@ in production in any form.
 
 Or remove 'postgresql' .Values.tests.enabled'
 
-Also, if you want to test your postgresql installation, you need to 
+Also, if you want to test your postgresql installation, you need to
 provide a postgres server yourself. Test itself doesn't deploy a server
 {{- end }}
 
 {{- if has "mysql" .Values.tests.enabled }}
 -----------------------------------------------------------------------
-You seem to have the mysql test set to true, usually, 
+You seem to have the mysql test set to true, usually,
 it shouldn't be done.
 
 Make sure that you want to run tests, and not using this installation
@@ -83,17 +98,17 @@ in production in any form.
 
 Or remove 'mysql' '.Values.tests.enabled'
 
-Also, if you want to test your mysql installation, you need to 
+Also, if you want to test your mysql installation, you need to
 provide a mysql server yourself. Test itself doesn't deploy a server
 {{- end }}
 
 {{- if has "crds" .Values.tests.enabled }}
 -----------------------------------------------------------------------
-You seem to have the crds test set to true, usually, 
+You seem to have the crds test set to true, usually,
 it shouldn't be done.
 
 !! This test uses a ClusterRole that has an access to all the resoucres
-in the cluster, so make sure that you want to run tests, 
+in the cluster, so make sure that you want to run tests,
 and not using this installation.
 
 Or remove 'crds' '.Values.tests.enabled'

--- a/charts/db-operator/templates/crds/kinda.rocks_dbinstances.yaml
+++ b/charts/db-operator/templates/crds/kinda.rocks_dbinstances.yaml
@@ -37,374 +37,393 @@ spec:
     listKind: DbInstanceList
     plural: dbinstances
     shortNames:
-      - dbin
+    - dbin
     singular: dbinstance
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: current phase
-          jsonPath: .status.phase
-          name: Phase
-          type: string
-        - description: health status
-          jsonPath: .status.status
-          name: Status
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: DbInstance is the Schema for the dbinstances API
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DbInstanceSpec defines the desired state of DbInstance
-              properties:
-                adminSecretRef:
-                  description:
-                    NamespacedName is a fork of the kubernetes api type of
-                    the same name. Sadly this is required because CRD structs must have
-                    all fields json tagged and the kubernetes type is not tagged.
-                  properties:
-                    Name:
-                      type: string
-                    Namespace:
-                      type: string
-                  required:
+  - additionalPrinterColumns:
+    - description: current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: health status
+      jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DbInstance is the Schema for the dbinstances API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DbInstanceSpec defines the desired state of DbInstance
+            properties:
+              adminSecretRef:
+                description: NamespacedName is a fork of the kubernetes api type of
+                  the same name. Sadly this is required because CRD structs must have
+                  all fields json tagged and the kubernetes type is not tagged.
+                properties:
+                  Name:
+                    type: string
+                  Namespace:
+                    type: string
+                required:
+                - Name
+                - Namespace
+                type: object
+              backup:
+                description: DbInstanceBackup defines name of google bucket to use
+                  for storing database dumps for backup when backup is enabled
+                properties:
+                  bucket:
+                    type: string
+                required:
+                - bucket
+                type: object
+              engine:
+                description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                type: string
+              generic:
+                description: GenericInstance is used when instance type is generic
+                  and describes necessary informations to use instance generic instance
+                  can be any backend, it must be reachable by described address and
+                  port
+                properties:
+                  backupHost:
+                    description: BackupHost address will be used for dumping database
+                      for backup Usually secondary address for primary-secondary setup
+                      or cluster lb address If it's not defined, above Host will be
+                      used as backup host address.
+                    type: string
+                  host:
+                    type: string
+                  port:
+                    type: integer
+                  publicIp:
+                    type: string
+                required:
+                - host
+                - port
+                type: object
+              google:
+                description: GoogleInstance is used when instance type is Google Cloud
+                  SQL and describes necessary informations to use google API to create
+                  sql instances
+                properties:
+                  apiEndpoint:
+                    type: string
+                  clientSecretRef:
+                    description: NamespacedName is a fork of the kubernetes api type
+                      of the same name. Sadly this is required because CRD structs
+                      must have all fields json tagged and the kubernetes type is
+                      not tagged.
+                    properties:
+                      Name:
+                        type: string
+                      Namespace:
+                        type: string
+                    required:
                     - Name
                     - Namespace
-                  type: object
-                backup:
-                  description:
-                    DbInstanceBackup defines name of google bucket to use
-                    for storing database dumps for backup when backup is enabled
-                  properties:
-                    bucket:
-                      type: string
-                  required:
-                    - bucket
-                  type: object
-                engine:
-                  description:
-                    'Important: Run "make generate" to regenerate code after
-                    modifying this file'
-                  type: string
-                generic:
-                  description:
-                    GenericInstance is used when instance type is generic
-                    and describes necessary informations to use instance generic instance
-                    can be any backend, it must be reachable by described address and
-                    port
-                  properties:
-                    backupHost:
-                      description:
-                        BackupHost address will be used for dumping database
-                        for backup Usually secondary address for primary-secondary setup
-                        or cluster lb address If it's not defined, above Host will be
-                        used as backup host address.
-                      type: string
-                    host:
-                      type: string
-                    port:
-                      type: integer
-                    publicIp:
-                      type: string
-                  required:
-                    - host
-                    - port
-                  type: object
-                google:
-                  description:
-                    GoogleInstance is used when instance type is Google Cloud
-                    SQL and describes necessary informations to use google API to create
-                    sql instances
-                  properties:
-                    apiEndpoint:
-                      type: string
-                    clientSecretRef:
-                      description:
-                        NamespacedName is a fork of the kubernetes api type
-                        of the same name. Sadly this is required because CRD structs
-                        must have all fields json tagged and the kubernetes type is
-                        not tagged.
-                      properties:
-                        Name:
-                          type: string
-                        Namespace:
-                          type: string
-                      required:
-                        - Name
-                        - Namespace
-                      type: object
-                    configmapRef:
-                      description:
-                        NamespacedName is a fork of the kubernetes api type
-                        of the same name. Sadly this is required because CRD structs
-                        must have all fields json tagged and the kubernetes type is
-                        not tagged.
-                      properties:
-                        Name:
-                          type: string
-                        Namespace:
-                          type: string
-                      required:
-                        - Name
-                        - Namespace
-                      type: object
-                    instance:
-                      type: string
-                  required:
-                    - configmapRef
-                    - instance
-                  type: object
-                monitoring:
-                  description: DbInstanceMonitoring defines if exporter
-                  properties:
-                    enabled:
-                      type: boolean
-                  required:
-                    - enabled
-                  type: object
-                sslConnection:
-                  description:
-                    DbInstanceSSLConnection defines weather connection from
-                    db-operator to instance has to be ssl or not
-                  properties:
-                    enabled:
-                      type: boolean
-                    skip-verify:
-                      description:
-                        SkipVerity use SSL connection, but don't check against
-                        a CA
-                      type: boolean
-                  required:
-                    - enabled
-                    - skip-verify
-                  type: object
-              required:
-                - adminSecretRef
-                - engine
-              type: object
-            status:
-              description: DbInstanceStatus defines the observed state of DbInstance
-              properties:
-                checksums:
-                  additionalProperties:
-                    type: string
-                  type: object
-                info:
-                  additionalProperties:
-                    type: string
-                  type: object
-                phase:
-                  description:
-                    'Important: Run "make generate" to regenerate code after
-                    modifying this file'
-                  type: string
-                status:
-                  type: boolean
-              required:
-                - phase
-                - status
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - description: current phase
-          jsonPath: .status.phase
-          name: Phase
-          type: string
-        - description: health status
-          jsonPath: .status.status
-          name: Status
-          type: string
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: DbInstance is the Schema for the dbinstances API
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DbInstanceSpec defines the desired state of DbInstance
-              properties:
-                adminSecretRef:
-                  description:
-                    NamespacedName is a fork of the kubernetes api type of
-                    the same name. Sadly this is required because CRD structs must have
-                    all fields json tagged and the kubernetes type is not tagged.
-                  properties:
-                    Name:
-                      type: string
-                    Namespace:
-                      type: string
-                  required:
+                    type: object
+                  configmapRef:
+                    description: NamespacedName is a fork of the kubernetes api type
+                      of the same name. Sadly this is required because CRD structs
+                      must have all fields json tagged and the kubernetes type is
+                      not tagged.
+                    properties:
+                      Name:
+                        type: string
+                      Namespace:
+                        type: string
+                    required:
                     - Name
                     - Namespace
-                  type: object
-                backup:
-                  description:
-                    DbInstanceBackup defines name of google bucket to use
-                    for storing database dumps for backup when backup is enabled
-                  properties:
-                    bucket:
-                      type: string
-                  required:
-                    - bucket
-                  type: object
-                engine:
-                  description:
-                    'Important: Run "make generate" to regenerate code after
-                    modifying this file'
-                  type: string
-                generic:
-                  description:
-                    GenericInstance is used when instance type is generic
-                    and describes necessary informations to use instance generic instance
-                    can be any backend, it must be reachable by described address and
-                    port
-                  properties:
-                    backupHost:
-                      description:
-                        BackupHost address will be used for dumping database
-                        for backup Usually secondary address for primary-secondary setup
-                        or cluster lb address If it's not defined, above Host will be
-                        used as backup host address.
-                      type: string
-                    host:
-                      type: string
-                    port:
-                      type: integer
-                    publicIp:
-                      type: string
-                  required:
-                    - host
-                    - port
-                  type: object
-                google:
-                  description:
-                    GoogleInstance is used when instance type is Google Cloud
-                    SQL and describes necessary informations to use google API to create
-                    sql instances
-                  properties:
-                    apiEndpoint:
-                      type: string
-                    clientSecretRef:
-                      description:
-                        NamespacedName is a fork of the kubernetes api type
-                        of the same name. Sadly this is required because CRD structs
-                        must have all fields json tagged and the kubernetes type is
-                        not tagged.
-                      properties:
-                        Name:
-                          type: string
-                        Namespace:
-                          type: string
-                      required:
-                        - Name
-                        - Namespace
-                      type: object
-                    configmapRef:
-                      description:
-                        NamespacedName is a fork of the kubernetes api type
-                        of the same name. Sadly this is required because CRD structs
-                        must have all fields json tagged and the kubernetes type is
-                        not tagged.
-                      properties:
-                        Name:
-                          type: string
-                        Namespace:
-                          type: string
-                      required:
-                        - Name
-                        - Namespace
-                      type: object
-                    instance:
-                      type: string
-                  required:
-                    - configmapRef
-                    - instance
-                  type: object
-                monitoring:
-                  description: DbInstanceMonitoring defines if exporter
-                  properties:
-                    enabled:
-                      type: boolean
-                  required:
-                    - enabled
-                  type: object
-                sslConnection:
-                  description:
-                    DbInstanceSSLConnection defines weather connection from
-                    db-operator to instance has to be ssl or not
-                  properties:
-                    enabled:
-                      type: boolean
-                    skip-verify:
-                      description:
-                        SkipVerity use SSL connection, but don't check against
-                        a CA
-                      type: boolean
-                  required:
-                    - enabled
-                    - skip-verify
-                  type: object
-              required:
-                - adminSecretRef
-                - engine
-              type: object
-            status:
-              description: DbInstanceStatus defines the observed state of DbInstance
-              properties:
-                checksums:
-                  additionalProperties:
+                    type: object
+                  instance:
                     type: string
-                  type: object
-                info:
-                  additionalProperties:
-                    type: string
-                  type: object
-                phase:
-                  description:
-                    'Important: Run "make generate" to regenerate code after
-                    modifying this file'
+                required:
+                - configmapRef
+                - instance
+                type: object
+              monitoring:
+                description: DbInstanceMonitoring defines if exporter
+                properties:
+                  enabled:
+                    type: boolean
+                required:
+                - enabled
+                type: object
+              sslConnection:
+                description: DbInstanceSSLConnection defines weather connection from
+                  db-operator to instance has to be ssl or not
+                properties:
+                  enabled:
+                    type: boolean
+                  skip-verify:
+                    description: SkipVerity use SSL connection, but don't check against
+                      a CA
+                    type: boolean
+                required:
+                - enabled
+                - skip-verify
+                type: object
+            required:
+            - adminSecretRef
+            - engine
+            type: object
+          status:
+            description: DbInstanceStatus defines the observed state of DbInstance
+            properties:
+              checksums:
+                additionalProperties:
                   type: string
-                status:
-                  type: boolean
-              required:
-                - phase
-                - status
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              info:
+                additionalProperties:
+                  type: string
+                type: object
+              phase:
+                description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                type: string
+              status:
+                type: boolean
+            required:
+            - phase
+            - status
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: current phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: health status
+      jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DbInstance is the Schema for the dbinstances API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DbInstanceSpec defines the desired state of DbInstance
+            properties:
+              adminSecretRef:
+                description: NamespacedName is a fork of the kubernetes api type of
+                  the same name. Sadly this is required because CRD structs must have
+                  all fields json tagged and the kubernetes type is not tagged.
+                properties:
+                  Name:
+                    type: string
+                  Namespace:
+                    type: string
+                required:
+                - Name
+                - Namespace
+                type: object
+              backup:
+                description: DbInstanceBackup defines name of google bucket to use
+                  for storing database dumps for backup when backup is enabled
+                properties:
+                  bucket:
+                    type: string
+                required:
+                - bucket
+                type: object
+              engine:
+                description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                type: string
+              generic:
+                description: GenericInstance is used when instance type is generic
+                  and describes necessary informations to use instance generic instance
+                  can be any backend, it must be reachable by described address and
+                  port
+                properties:
+                  backupHost:
+                    description: BackupHost address will be used for dumping database
+                      for backup Usually secondary address for primary-secondary setup
+                      or cluster lb address If it's not defined, above Host will be
+                      used as backup host address.
+                    type: string
+                  host:
+                    type: string
+                  hostFrom:
+                    properties:
+                      key:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - key
+                    - kind
+                    - name
+                    - namespace
+                    type: object
+                  port:
+                    type: integer
+                  portFrom:
+                    properties:
+                      key:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - key
+                    - kind
+                    - name
+                    - namespace
+                    type: object
+                  publicIp:
+                    type: string
+                  publicIpFrom:
+                    properties:
+                      key:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - key
+                    - kind
+                    - name
+                    - namespace
+                    type: object
+                type: object
+              google:
+                description: GoogleInstance is used when instance type is Google Cloud
+                  SQL and describes necessary informations to use google API to create
+                  sql instances
+                properties:
+                  apiEndpoint:
+                    type: string
+                  clientSecretRef:
+                    description: NamespacedName is a fork of the kubernetes api type
+                      of the same name. Sadly this is required because CRD structs
+                      must have all fields json tagged and the kubernetes type is
+                      not tagged.
+                    properties:
+                      Name:
+                        type: string
+                      Namespace:
+                        type: string
+                    required:
+                    - Name
+                    - Namespace
+                    type: object
+                  configmapRef:
+                    description: NamespacedName is a fork of the kubernetes api type
+                      of the same name. Sadly this is required because CRD structs
+                      must have all fields json tagged and the kubernetes type is
+                      not tagged.
+                    properties:
+                      Name:
+                        type: string
+                      Namespace:
+                        type: string
+                    required:
+                    - Name
+                    - Namespace
+                    type: object
+                  instance:
+                    type: string
+                required:
+                - configmapRef
+                - instance
+                type: object
+              monitoring:
+                description: DbInstanceMonitoring defines if exporter
+                properties:
+                  enabled:
+                    type: boolean
+                required:
+                - enabled
+                type: object
+              sslConnection:
+                description: DbInstanceSSLConnection defines weather connection from
+                  db-operator to instance has to be ssl or not
+                properties:
+                  enabled:
+                    type: boolean
+                  skip-verify:
+                    description: SkipVerity use SSL connection, but don't check against
+                      a CA
+                    type: boolean
+                required:
+                - enabled
+                - skip-verify
+                type: object
+            required:
+            - adminSecretRef
+            - engine
+            type: object
+          status:
+            description: DbInstanceStatus defines the observed state of DbInstance
+            properties:
+              checksums:
+                additionalProperties:
+                  type: string
+                type: object
+              info:
+                additionalProperties:
+                  type: string
+                type: object
+              phase:
+                description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                type: string
+              status:
+                type: boolean
+            required:
+            - phase
+            - status
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 {{- end }}

--- a/charts/db-operator/templates/test/postgres-test-from-cm.yaml
+++ b/charts/db-operator/templates/test/postgres-test-from-cm.yaml
@@ -1,0 +1,211 @@
+{{- if has "postgresql-from-cm" .Values.tests.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name:  {{ template "db-operator.name" . }}-postgresql-admin-password
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    {{- if .Values.tests.cleanup }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+    "helm.sh/hook-weight": "1"
+type: Opaque
+data:
+  password: {{ .Values.tests.postgresql.admin.password | b64enc }}
+  user: {{ .Values.tests.postgresql.admin.user | b64enc }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  {{ template "db-operator.name" . }}-postgresql-config
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    {{- if .Values.tests.cleanup }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+    "helm.sh/hook-weight": "1"
+data:
+  host: {{ .Values.tests.postgresql.service.name }}.{{ .Values.tests.postgresql.service.namespace }}.svc.cluster.local
+  port: "5432"
+  publicIp: "1.2.3.4"
+---
+apiVersion: kinda.rocks/v1beta1
+kind: DbInstance
+metadata:
+  name:  {{ template "db-operator.name" . }}-postgresql
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    {{- if .Values.tests.cleanup }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+    "helm.sh/hook-weight": "1"
+spec:
+  adminSecretRef:
+    Namespace: {{ .Release.Namespace }}
+    Name:  {{ template "db-operator.name" . }}-postgresql-admin-password
+  engine: postgres
+  generic:
+    hostFrom:
+      kind: ConfigMap
+      name: {{ template "db-operator.name" . }}-postgresql-config
+      namespace: {{ .Release.Namespace }}
+      key: host
+    portFrom:
+      kind: ConfigMap
+      name: {{ template "db-operator.name" . }}-postgresql-config
+      namespace: {{ .Release.Namespace }}
+      key: port
+    publicIpFrom:
+      kind: ConfigMap
+      name: {{ template "db-operator.name" . }}-postgresql-config
+      namespace: {{ .Release.Namespace }}
+      key: publicIp
+    backupHost: {{ .Values.tests.postgresql.service.name }}.{{ .Values.tests.postgresql.service.namespace }}.svc.cluster.local
+
+---
+apiVersion: "kinda.rocks/v1beta1"
+kind: "Database"
+metadata:
+  name: {{ template "db-operator.name" . }}-postgresql
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    {{- if .Values.tests.cleanup }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+    "helm.sh/hook-weight": "2"
+spec:
+  secretName: {{ template "db-operator.name" . }}-postgresql-credentials
+  instance: {{ template "db-operator.name" . }}-postgresql
+  backup:
+    enable: false
+    cron: ""
+  deletionProtected: true
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "db-operator.name" . }}-postgresql-test-script
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    {{- if .Values.tests.cleanup }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+    "helm.sh/hook-weight": "3"
+data:
+  write.sh: |
+{{ .Files.Get "scripts/postgresql/test_write.sh" | indent 4}}
+  read.sh: |
+{{ .Files.Get "scripts/postgresql/test_read.sh" | indent 4}}
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "db-operator.name" . }}-tester-app-{{ randAlphaNum 5 | lower }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    {{- if .Values.tests.cleanup }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+    "helm.sh/hook-weight": "4"
+spec:
+  containers:
+  - name: postgres-writer
+    image: postgres:10.4
+    command:
+      - sh
+      - -c
+      - exec sh /app/write.sh
+    env:
+      - name: POSTGRES_PASSWORD_FILE
+        value: /run/secrets/postgres/POSTGRES_PASSWORD
+      - name: POSTGRES_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "db-operator.name" . }}-postgresql-credentials
+            key: POSTGRES_USER
+      - name: POSTGRES_DB
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "db-operator.name" . }}-postgresql-credentials
+            key: POSTGRES_DB
+      - name: POSTGRES_HOST
+        valueFrom:
+          configMapKeyRef:
+            name: {{ template "db-operator.name" . }}-postgresql-credentials
+            key: DB_CONN
+    volumeMounts:
+      - name: db-secret
+        mountPath: /run/secrets/postgres/
+        readOnly: true
+      - name: script
+        mountPath: /app/
+      - name: shared-data
+        mountPath: /tmp
+    imagePullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  - name: postgres-reader
+    image: postgres:10.4
+    command:
+      - sh
+      - -c
+      - exec sh /app/read.sh
+    env:
+      - name: POSTGRES_PASSWORD_FILE
+        value: /run/secrets/postgres/POSTGRES_PASSWORD
+      - name: POSTGRES_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "db-operator.name" . }}-postgresql-credentials
+            key: POSTGRES_USER
+      - name: POSTGRES_DB
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "db-operator.name" . }}-postgresql-credentials
+            key: POSTGRES_DB
+      - name: POSTGRES_HOST
+        valueFrom:
+          configMapKeyRef:
+            name: {{ template "db-operator.name" . }}-postgresql-credentials
+            key: DB_CONN
+    volumeMounts:
+      - name: db-secret
+        mountPath: /run/secrets/postgres/
+        readOnly: true
+      - name: script
+        mountPath: /app/
+      - name: shared-data
+        mountPath: /tmp
+    imagePullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  restartPolicy: Never
+  volumes:
+    - name: db-secret
+      secret:
+        secretName: {{ template "db-operator.name" . }}-postgresql-credentials
+    - name: script
+      configMap:
+        name: {{ template "db-operator.name" . }}-postgresql-test-script
+    - name: shared-data
+      emptyDir: {}
+{{- end }}


### PR DESCRIPTION
DbInstance now can get a port, a host and a public ip from configmaps/secrets

Also, the dbinstance validation webhook is printing a message that google instances are deprecated

db-operator issue: https://github.com/db-operator/db-operator/pull/102