### PR TITLE
Set db-operator version on database CR during full reconcile

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: db-operator
-version: 1.23.0
+version: 1.24.0
 # ---------------------------------------------------------------------------------
 # -- All supported k8s versions are in the test:
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.24.0
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml
 # ---------------------------------------------------------------------------------
 kubeVersion: ">= 1.22-prerelease"
-appVersion: "2.5.1"
+appVersion: "2.6.0"
 description: The DB Operator creates databases and make them available in the cluster via Custom Resource.
 home: https://github.com/db-operator/db-operator
 maintainers:

--- a/charts/db-operator/README.md
+++ b/charts/db-operator/README.md
@@ -169,6 +169,13 @@ After changing default `Values`, please execute `make gen_docs` to update the `R
 If there is an breaking change, or something that might make the upgrade complicated, it should be described here
 
 <details>
+  <summary>To `v1.24.0`</summary>
+
+The `Database` CRD now includes the version of the db-operator that ran the last full reconciliation in the required status field `operatorVersion`. This change can help with debugging problems with the db-operator, as previously it wasn't always clear whether an expected fix from a db-operator upgrade had been applied to the databases. If you manage CRDs outside the chart, make sure you update them, otherwise your deployment may break.
+
+</details>
+
+<details>
   <summary>To `v1.11.0`</summary>
 Additional selectors were added to the default templates in an attempt to follow the same labelling scheme everywhere, but since selectors are immutable, the upgrade will require removing of the db-operator deployment.
 

--- a/charts/db-operator/templates/NOTES.txt
+++ b/charts/db-operator/templates/NOTES.txt
@@ -24,22 +24,12 @@ The Release name {{ .Release.Name }}.
 -----------------------------------------------------------------------
 Breaking changes and migration paths:
 
-{{ .Chart.Version }} is not breaking, you don't have to worry
+{{ .Chart.Version }} introduces a new status field "operatorVersion" 
+to the Database CRD. This change is not breaking if your CRDs are
+managed by this Helm chart. Otherwise if you're deploying them separately, 
+please read the migration plan below:
 
-Noticeable and important changes:
-
-In {{ .Chart.Version }} google instances are deprecated, they will be
-removed in the next API version (v1beta2)
-
-Please see this issue:
-  https://github.com/db-operator/db-operator/issues/96
-
-We will not remove google instances support within next 6 months after
-{{ .Release.Version }} is released, so users should have enough time
-for migration.
-
-If you have questions, please feel free to create issues here:
-  https://github.com/db-operator/db-operator/issues/96
+https://github.com/db-operator/charts/tree/main/charts/db-operator#upgrading
 
 {{- if not .Values.crds.install }}
 -----------------------------------------------------------------------

--- a/charts/db-operator/templates/crds/kinda.rocks_databases.yaml
+++ b/charts/db-operator/templates/crds/kinda.rocks_databases.yaml
@@ -68,16 +68,19 @@ spec:
           description: Database is the Schema for the databases API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -85,8 +88,7 @@ spec:
               description: DatabaseSpec defines the desired state of Database
               properties:
                 backup:
-                  description:
-                    DatabaseBackup defines the desired state of backup and
+                  description: DatabaseBackup defines the desired state of backup and
                     schedule
                   properties:
                     cron:
@@ -100,13 +102,11 @@ spec:
                 cleanup:
                   type: boolean
                 connectionStringTemplate:
-                  description:
-                    'ConnectionStringTemplate field can be used to pass a
-                    custom template for generating a db connection string. These keywords
-                    can be used: Protocol, DatabaseHost, DatabasePort, UserName, Password,
-                    DatabaseName. Default template looks like this: "{{ .Protocol }}://{{
-                    .UserName }}:{{ .Password }}@{{ .DatabaseHost }}:{{ .DatabasePort
-                    }}/{{ .DatabaseName }}"'
+                  description: |-
+                    ConnectionStringTemplate field can be used to pass a custom template for generating a db connection string.
+                    These keywords can be used: Protocol, DatabaseHost, DatabasePort, UserName, Password, DatabaseName.
+                    Default template looks like this:
+                    "{{ .Protocol }}://{{ .UserName }}:{{ .Password }}@{{ .DatabaseHost }}:{{ .DatabasePort }}/{{ .DatabaseName }}"
                   type: string
                 deletionProtected:
                   type: boolean
@@ -117,18 +117,15 @@ spec:
                 instance:
                   type: string
                 postgres:
-                  description:
-                    Postgres struct should be used to provide resource that
+                  description: Postgres struct should be used to provide resource that
                     only applicable to postgres
                   properties:
                     dropPublicSchema:
-                      description:
-                        If set to true, the public schema will be dropped
+                      description: If set to true, the public schema will be dropped
                         after the database creation
                       type: boolean
                     schemas:
-                      description:
-                        Specify schemas to be created. The user created by
+                      description: Specify schemas to be created. The user created by
                         db-operator will have all access on them.
                       items:
                         type: string
@@ -155,18 +152,19 @@ spec:
                   description: DbInstance is the Schema for the dbinstances API
                   properties:
                     apiVersion:
-                      description:
-                        "APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an object.
+                        Servers should convert recognized schemas to the latest internal value, and
+                        may reject unrecognized values.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                       type: string
                     kind:
-                      description:
-                        "Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                      description: |-
+                        Kind is a string value representing the REST resource this object represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     metadata:
                       type: object
@@ -174,11 +172,9 @@ spec:
                       description: DbInstanceSpec defines the desired state of DbInstance
                       properties:
                         adminSecretRef:
-                          description:
-                            NamespacedName is a fork of the kubernetes api
-                            type of the same name. Sadly this is required because CRD
-                            structs must have all fields json tagged and the kubernetes
-                            type is not tagged.
+                          description: |-
+                            NamespacedName is a fork of the kubernetes api type of the same name.
+                            Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
                           properties:
                             Name:
                               type: string
@@ -189,8 +185,7 @@ spec:
                             - Namespace
                           type: object
                         backup:
-                          description:
-                            DbInstanceBackup defines name of google bucket
+                          description: DbInstanceBackup defines name of google bucket
                             to use for storing database dumps for backup when backup
                             is enabled
                           properties:
@@ -200,23 +195,20 @@ spec:
                             - bucket
                           type: object
                         engine:
-                          description:
-                            'Important: Run "make generate" to regenerate
-                            code after modifying this file'
+                          description: 'Important: Run "make generate" to regenerate
+                          code after modifying this file'
                           type: string
                         generic:
-                          description:
-                            GenericInstance is used when instance type is
-                            generic and describes necessary informations to use instance
-                            generic instance can be any backend, it must be reachable
-                            by described address and port
+                          description: |-
+                            GenericInstance is used when instance type is generic
+                            and describes necessary informations to use instance
+                            generic instance can be any backend, it must be reachable by described address and port
                           properties:
                             backupHost:
-                              description:
-                                BackupHost address will be used for dumping
-                                database for backup Usually secondary address for primary-secondary
-                                setup or cluster lb address If it's not defined, above
-                                Host will be used as backup host address.
+                              description: |-
+                                BackupHost address will be used for dumping database for backup
+                                Usually secondary address for primary-secondary setup or cluster lb address
+                                If it's not defined, above Host will be used as backup host address.
                               type: string
                             host:
                               type: string
@@ -229,19 +221,16 @@ spec:
                             - port
                           type: object
                         google:
-                          description:
-                            GoogleInstance is used when instance type is
-                            Google Cloud SQL and describes necessary informations to
-                            use google API to create sql instances
+                          description: |-
+                            GoogleInstance is used when instance type is Google Cloud SQL
+                            and describes necessary informations to use google API to create sql instances
                           properties:
                             apiEndpoint:
                               type: string
                             clientSecretRef:
-                              description:
-                                NamespacedName is a fork of the kubernetes
-                                api type of the same name. Sadly this is required because
-                                CRD structs must have all fields json tagged and the
-                                kubernetes type is not tagged.
+                              description: |-
+                                NamespacedName is a fork of the kubernetes api type of the same name.
+                                Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
                               properties:
                                 Name:
                                   type: string
@@ -252,11 +241,9 @@ spec:
                                 - Namespace
                               type: object
                             configmapRef:
-                              description:
-                                NamespacedName is a fork of the kubernetes
-                                api type of the same name. Sadly this is required because
-                                CRD structs must have all fields json tagged and the
-                                kubernetes type is not tagged.
+                              description: |-
+                                NamespacedName is a fork of the kubernetes api type of the same name.
+                                Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
                               properties:
                                 Name:
                                   type: string
@@ -281,15 +268,13 @@ spec:
                             - enabled
                           type: object
                         sslConnection:
-                          description:
-                            DbInstanceSSLConnection defines weather connection
+                          description: DbInstanceSSLConnection defines weather connection
                             from db-operator to instance has to be ssl or not
                           properties:
                             enabled:
                               type: boolean
                             skip-verify:
-                              description:
-                                SkipVerity use SSL connection, but don't
+                              description: SkipVerity use SSL connection, but don't
                                 check against a CA
                               type: boolean
                           required:
@@ -312,9 +297,8 @@ spec:
                             type: string
                           type: object
                         phase:
-                          description:
-                            'Important: Run "make generate" to regenerate
-                            code after modifying this file'
+                          description: 'Important: Run "make generate" to regenerate
+                          code after modifying this file'
                           type: string
                         status:
                           type: boolean
@@ -326,15 +310,14 @@ spec:
                 monitorUserSecret:
                   type: string
                 phase:
-                  description:
-                    'Important: Run "make generate" to regenerate code after
-                    modifying this file Add custom validation using kubebuilder tags:
-                    https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  description: |-
+                    Important: Run "make generate" to regenerate code after modifying this file
+                    Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
                   type: string
                 proxyStatus:
-                  description:
-                    DatabaseProxyStatus defines whether proxy for database
-                    is enabled or not if so, provide information
+                  description: |-
+                    DatabaseProxyStatus defines whether proxy for database is enabled or not
+                    if so, provide information
                   properties:
                     serviceName:
                       type: string
@@ -377,6 +360,10 @@ spec:
           jsonPath: .spec.instance
           name: DBInstance
           type: string
+        - description: db-operator version of last full reconcile
+          jsonPath: .status.operatorVersion
+          name: OperatorVersion
+          type: string
         - description: time since creation of resource
           jsonPath: .metadata.creationTimestamp
           name: Age
@@ -387,16 +374,19 @@ spec:
           description: Database is the Schema for the databases API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -404,8 +394,7 @@ spec:
               description: DatabaseSpec defines the desired state of Database
               properties:
                 backup:
-                  description:
-                    DatabaseBackup defines the desired state of backup and
+                  description: DatabaseBackup defines the desired state of backup and
                     schedule
                   properties:
                     cron:
@@ -419,19 +408,16 @@ spec:
                 cleanup:
                   type: boolean
                 credentials:
-                  description:
-                    "Credentials should be used to setup everything relates
-                    to k8s secrets and configmaps TODO(@allanger): Field .spec.secretName
-                    should be moved here in the v1beta2 version"
+                  description: |-
+                    Credentials should be used to setup everything relates to k8s secrets and configmaps
+                    TODO(@allanger): Field .spec.secretName should be moved here in the v1beta2 version
                   properties:
                     templates:
-                      description:
-                        Templates to add custom entries to ConfigMaps and
+                      description: Templates to add custom entries to ConfigMaps and
                         Secrets
                       items:
-                        description:
-                          Tempaltes to add custom entries to comfigmaps and
-                          secrets
+                        description: Tempaltes to add custom entries to ConfigMaps and
+                          Secrets
                         properties:
                           name:
                             type: string
@@ -451,13 +437,11 @@ spec:
                 instance:
                   type: string
                 postgres:
-                  description:
-                    Postgres struct should be used to provide resource that
+                  description: Postgres struct should be used to provide resource that
                     only applicable to postgres
                   properties:
                     dropPublicSchema:
-                      description:
-                        If set to true, the public schema will be dropped
+                      description: If set to true, the public schema will be dropped
                         after the database creation
                       type: boolean
                     extensions:
@@ -465,8 +449,7 @@ spec:
                         type: string
                       type: array
                     schemas:
-                      description:
-                        Specify schemas to be created. The user created by
+                      description: Specify schemas to be created. The user created by
                         db-operator will have all access on them.
                       items:
                         type: string
@@ -496,10 +479,12 @@ spec:
                   type: string
                 monitorUserSecret:
                   type: string
+                operatorVersion:
+                  type: string
                 proxyStatus:
-                  description:
-                    DatabaseProxyStatus defines whether proxy for database
-                    is enabled or not if so, provide information
+                  description: |-
+                    DatabaseProxyStatus defines whether proxy for database is enabled or not
+                    if so, provide information
                   properties:
                     serviceName:
                       type: string
@@ -514,12 +499,16 @@ spec:
                     - status
                   type: object
                 status:
+                  description: |-
+                    Important: Run "make generate" to regenerate code after modifying this file
+                    Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
                   type: boolean
                 user:
                   type: string
               required:
                 - database
                 - engine
+                - operatorVersion
                 - status
                 - user
               type: object

--- a/charts/db-operator/templates/crds/kinda.rocks_dbinstances.yaml
+++ b/charts/db-operator/templates/crds/kinda.rocks_dbinstances.yaml
@@ -37,393 +37,399 @@ spec:
     listKind: DbInstanceList
     plural: dbinstances
     shortNames:
-    - dbin
+      - dbin
     singular: dbinstance
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: current phase
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - description: health status
-      jsonPath: .status.status
-      name: Status
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: DbInstance is the Schema for the dbinstances API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DbInstanceSpec defines the desired state of DbInstance
-            properties:
-              adminSecretRef:
-                description: NamespacedName is a fork of the kubernetes api type of
-                  the same name. Sadly this is required because CRD structs must have
-                  all fields json tagged and the kubernetes type is not tagged.
-                properties:
-                  Name:
-                    type: string
-                  Namespace:
-                    type: string
-                required:
-                - Name
-                - Namespace
-                type: object
-              backup:
-                description: DbInstanceBackup defines name of google bucket to use
-                  for storing database dumps for backup when backup is enabled
-                properties:
-                  bucket:
-                    type: string
-                required:
-                - bucket
-                type: object
-              engine:
-                description: 'Important: Run "make generate" to regenerate code after
-                  modifying this file'
-                type: string
-              generic:
-                description: GenericInstance is used when instance type is generic
-                  and describes necessary informations to use instance generic instance
-                  can be any backend, it must be reachable by described address and
-                  port
-                properties:
-                  backupHost:
-                    description: BackupHost address will be used for dumping database
-                      for backup Usually secondary address for primary-secondary setup
-                      or cluster lb address If it's not defined, above Host will be
-                      used as backup host address.
-                    type: string
-                  host:
-                    type: string
-                  port:
-                    type: integer
-                  publicIp:
-                    type: string
-                required:
-                - host
-                - port
-                type: object
-              google:
-                description: GoogleInstance is used when instance type is Google Cloud
-                  SQL and describes necessary informations to use google API to create
-                  sql instances
-                properties:
-                  apiEndpoint:
-                    type: string
-                  clientSecretRef:
-                    description: NamespacedName is a fork of the kubernetes api type
-                      of the same name. Sadly this is required because CRD structs
-                      must have all fields json tagged and the kubernetes type is
-                      not tagged.
-                    properties:
-                      Name:
-                        type: string
-                      Namespace:
-                        type: string
-                    required:
+    - additionalPrinterColumns:
+        - description: current phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: health status
+          jsonPath: .status.status
+          name: Status
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DbInstance is the Schema for the dbinstances API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DbInstanceSpec defines the desired state of DbInstance
+              properties:
+                adminSecretRef:
+                  description: |-
+                    NamespacedName is a fork of the kubernetes api type of the same name.
+                    Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
+                  properties:
+                    Name:
+                      type: string
+                    Namespace:
+                      type: string
+                  required:
                     - Name
                     - Namespace
-                    type: object
-                  configmapRef:
-                    description: NamespacedName is a fork of the kubernetes api type
-                      of the same name. Sadly this is required because CRD structs
-                      must have all fields json tagged and the kubernetes type is
-                      not tagged.
-                    properties:
-                      Name:
-                        type: string
-                      Namespace:
-                        type: string
-                    required:
+                  type: object
+                backup:
+                  description: DbInstanceBackup defines name of google bucket to use
+                    for storing database dumps for backup when backup is enabled
+                  properties:
+                    bucket:
+                      type: string
+                  required:
+                    - bucket
+                  type: object
+                engine:
+                  description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                  type: string
+                generic:
+                  description: |-
+                    GenericInstance is used when instance type is generic
+                    and describes necessary informations to use instance
+                    generic instance can be any backend, it must be reachable by described address and port
+                  properties:
+                    backupHost:
+                      description: |-
+                        BackupHost address will be used for dumping database for backup
+                        Usually secondary address for primary-secondary setup or cluster lb address
+                        If it's not defined, above Host will be used as backup host address.
+                      type: string
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    publicIp:
+                      type: string
+                  required:
+                    - host
+                    - port
+                  type: object
+                google:
+                  description: |-
+                    GoogleInstance is used when instance type is Google Cloud SQL
+                    and describes necessary informations to use google API to create sql instances
+                  properties:
+                    apiEndpoint:
+                      type: string
+                    clientSecretRef:
+                      description: |-
+                        NamespacedName is a fork of the kubernetes api type of the same name.
+                        Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
+                      properties:
+                        Name:
+                          type: string
+                        Namespace:
+                          type: string
+                      required:
+                        - Name
+                        - Namespace
+                      type: object
+                    configmapRef:
+                      description: |-
+                        NamespacedName is a fork of the kubernetes api type of the same name.
+                        Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
+                      properties:
+                        Name:
+                          type: string
+                        Namespace:
+                          type: string
+                      required:
+                        - Name
+                        - Namespace
+                      type: object
+                    instance:
+                      type: string
+                  required:
+                    - configmapRef
+                    - instance
+                  type: object
+                monitoring:
+                  description: DbInstanceMonitoring defines if exporter
+                  properties:
+                    enabled:
+                      type: boolean
+                  required:
+                    - enabled
+                  type: object
+                sslConnection:
+                  description: DbInstanceSSLConnection defines weather connection from
+                    db-operator to instance has to be ssl or not
+                  properties:
+                    enabled:
+                      type: boolean
+                    skip-verify:
+                      description: SkipVerity use SSL connection, but don't check against
+                        a CA
+                      type: boolean
+                  required:
+                    - enabled
+                    - skip-verify
+                  type: object
+              required:
+                - adminSecretRef
+                - engine
+              type: object
+            status:
+              description: DbInstanceStatus defines the observed state of DbInstance
+              properties:
+                checksums:
+                  additionalProperties:
+                    type: string
+                  type: object
+                info:
+                  additionalProperties:
+                    type: string
+                  type: object
+                phase:
+                  description: 'Important: Run "make generate" to regenerate code after
+                  modifying this file'
+                  type: string
+                status:
+                  type: boolean
+              required:
+                - phase
+                - status
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: { }
+    - additionalPrinterColumns:
+        - description: current phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: health status
+          jsonPath: .status.status
+          name: Status
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: DbInstance is the Schema for the dbinstances API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DbInstanceSpec defines the desired state of DbInstance
+              properties:
+                adminSecretRef:
+                  description: |-
+                    NamespacedName is a fork of the kubernetes api type of the same name.
+                    Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
+                  properties:
+                    Name:
+                      type: string
+                    Namespace:
+                      type: string
+                  required:
                     - Name
                     - Namespace
-                    type: object
-                  instance:
-                    type: string
-                required:
-                - configmapRef
-                - instance
-                type: object
-              monitoring:
-                description: DbInstanceMonitoring defines if exporter
-                properties:
-                  enabled:
-                    type: boolean
-                required:
-                - enabled
-                type: object
-              sslConnection:
-                description: DbInstanceSSLConnection defines weather connection from
-                  db-operator to instance has to be ssl or not
-                properties:
-                  enabled:
-                    type: boolean
-                  skip-verify:
-                    description: SkipVerity use SSL connection, but don't check against
-                      a CA
-                    type: boolean
-                required:
-                - enabled
-                - skip-verify
-                type: object
-            required:
-            - adminSecretRef
-            - engine
-            type: object
-          status:
-            description: DbInstanceStatus defines the observed state of DbInstance
-            properties:
-              checksums:
-                additionalProperties:
-                  type: string
-                type: object
-              info:
-                additionalProperties:
-                  type: string
-                type: object
-              phase:
-                description: 'Important: Run "make generate" to regenerate code after
+                  type: object
+                backup:
+                  description: DbInstanceBackup defines name of google bucket to use
+                    for storing database dumps for backup when backup is enabled
+                  properties:
+                    bucket:
+                      type: string
+                  required:
+                    - bucket
+                  type: object
+                engine:
+                  description: 'Important: Run "make generate" to regenerate code after
                   modifying this file'
-                type: string
-              status:
-                type: boolean
-            required:
-            - phase
-            - status
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: current phase
-      jsonPath: .status.phase
-      name: Phase
-      type: string
-    - description: health status
-      jsonPath: .status.status
-      name: Status
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: DbInstance is the Schema for the dbinstances API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DbInstanceSpec defines the desired state of DbInstance
-            properties:
-              adminSecretRef:
-                description: NamespacedName is a fork of the kubernetes api type of
-                  the same name. Sadly this is required because CRD structs must have
-                  all fields json tagged and the kubernetes type is not tagged.
-                properties:
-                  Name:
-                    type: string
-                  Namespace:
-                    type: string
-                required:
-                - Name
-                - Namespace
-                type: object
-              backup:
-                description: DbInstanceBackup defines name of google bucket to use
-                  for storing database dumps for backup when backup is enabled
-                properties:
-                  bucket:
-                    type: string
-                required:
-                - bucket
-                type: object
-              engine:
-                description: 'Important: Run "make generate" to regenerate code after
-                  modifying this file'
-                type: string
-              generic:
-                description: GenericInstance is used when instance type is generic
-                  and describes necessary informations to use instance generic instance
-                  can be any backend, it must be reachable by described address and
-                  port
-                properties:
-                  backupHost:
-                    description: BackupHost address will be used for dumping database
-                      for backup Usually secondary address for primary-secondary setup
-                      or cluster lb address If it's not defined, above Host will be
-                      used as backup host address.
-                    type: string
-                  host:
-                    type: string
-                  hostFrom:
-                    properties:
-                      key:
-                        type: string
-                      kind:
-                        type: string
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - key
-                    - kind
-                    - name
-                    - namespace
-                    type: object
-                  port:
-                    type: integer
-                  portFrom:
-                    properties:
-                      key:
-                        type: string
-                      kind:
-                        type: string
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - key
-                    - kind
-                    - name
-                    - namespace
-                    type: object
-                  publicIp:
-                    type: string
-                  publicIpFrom:
-                    properties:
-                      key:
-                        type: string
-                      kind:
-                        type: string
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - key
-                    - kind
-                    - name
-                    - namespace
-                    type: object
-                type: object
-              google:
-                description: GoogleInstance is used when instance type is Google Cloud
-                  SQL and describes necessary informations to use google API to create
-                  sql instances
-                properties:
-                  apiEndpoint:
-                    type: string
-                  clientSecretRef:
-                    description: NamespacedName is a fork of the kubernetes api type
-                      of the same name. Sadly this is required because CRD structs
-                      must have all fields json tagged and the kubernetes type is
-                      not tagged.
-                    properties:
-                      Name:
-                        type: string
-                      Namespace:
-                        type: string
-                    required:
-                    - Name
-                    - Namespace
-                    type: object
-                  configmapRef:
-                    description: NamespacedName is a fork of the kubernetes api type
-                      of the same name. Sadly this is required because CRD structs
-                      must have all fields json tagged and the kubernetes type is
-                      not tagged.
-                    properties:
-                      Name:
-                        type: string
-                      Namespace:
-                        type: string
-                    required:
-                    - Name
-                    - Namespace
-                    type: object
-                  instance:
-                    type: string
-                required:
-                - configmapRef
-                - instance
-                type: object
-              monitoring:
-                description: DbInstanceMonitoring defines if exporter
-                properties:
-                  enabled:
-                    type: boolean
-                required:
-                - enabled
-                type: object
-              sslConnection:
-                description: DbInstanceSSLConnection defines weather connection from
-                  db-operator to instance has to be ssl or not
-                properties:
-                  enabled:
-                    type: boolean
-                  skip-verify:
-                    description: SkipVerity use SSL connection, but don't check against
-                      a CA
-                    type: boolean
-                required:
-                - enabled
-                - skip-verify
-                type: object
-            required:
-            - adminSecretRef
-            - engine
-            type: object
-          status:
-            description: DbInstanceStatus defines the observed state of DbInstance
-            properties:
-              checksums:
-                additionalProperties:
                   type: string
-                type: object
-              info:
-                additionalProperties:
-                  type: string
-                type: object
-              phase:
-                description: 'Important: Run "make generate" to regenerate code after
+                generic:
+                  description: |-
+                    GenericInstance is used when instance type is generic
+                    and describes necessary informations to use instance
+                    generic instance can be any backend, it must be reachable by described address and port
+                  properties:
+                    backupHost:
+                      description: |-
+                        BackupHost address will be used for dumping database for backup
+                        Usually secondary address for primary-secondary setup or cluster lb address
+                        If it's not defined, above Host will be used as backup host address.
+                      type: string
+                    host:
+                      type: string
+                    hostFrom:
+                      properties:
+                        key:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - key
+                        - kind
+                        - name
+                        - namespace
+                      type: object
+                    port:
+                      type: integer
+                    portFrom:
+                      properties:
+                        key:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - key
+                        - kind
+                        - name
+                        - namespace
+                      type: object
+                    publicIp:
+                      type: string
+                    publicIpFrom:
+                      properties:
+                        key:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - key
+                        - kind
+                        - name
+                        - namespace
+                      type: object
+                  type: object
+                google:
+                  description: |-
+                    GoogleInstance is used when instance type is Google Cloud SQL
+                    and describes necessary informations to use google API to create sql instances
+                  properties:
+                    apiEndpoint:
+                      type: string
+                    clientSecretRef:
+                      description: |-
+                        NamespacedName is a fork of the kubernetes api type of the same name.
+                        Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
+                      properties:
+                        Name:
+                          type: string
+                        Namespace:
+                          type: string
+                      required:
+                        - Name
+                        - Namespace
+                      type: object
+                    configmapRef:
+                      description: |-
+                        NamespacedName is a fork of the kubernetes api type of the same name.
+                        Sadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.
+                      properties:
+                        Name:
+                          type: string
+                        Namespace:
+                          type: string
+                      required:
+                        - Name
+                        - Namespace
+                      type: object
+                    instance:
+                      type: string
+                  required:
+                    - configmapRef
+                    - instance
+                  type: object
+                monitoring:
+                  description: DbInstanceMonitoring defines if exporter
+                  properties:
+                    enabled:
+                      type: boolean
+                  required:
+                    - enabled
+                  type: object
+                sslConnection:
+                  description: DbInstanceSSLConnection defines weather connection from
+                    db-operator to instance has to be ssl or not
+                  properties:
+                    enabled:
+                      type: boolean
+                    skip-verify:
+                      description: SkipVerity use SSL connection, but don't check against
+                        a CA
+                      type: boolean
+                  required:
+                    - enabled
+                    - skip-verify
+                  type: object
+              required:
+                - adminSecretRef
+                - engine
+              type: object
+            status:
+              description: DbInstanceStatus defines the observed state of DbInstance
+              properties:
+                checksums:
+                  additionalProperties:
+                    type: string
+                  type: object
+                info:
+                  additionalProperties:
+                    type: string
+                  type: object
+                phase:
+                  description: 'Important: Run "make generate" to regenerate code after
                   modifying this file'
-                type: string
-              status:
-                type: boolean
-            required:
-            - phase
-            - status
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: string
+                status:
+                  type: boolean
+              required:
+                - phase
+                - status
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: { }
 {{- end }}

--- a/charts/db-operator/templates/crds/kinda.rocks_dbuser.yaml
+++ b/charts/db-operator/templates/crds/kinda.rocks_dbuser.yaml
@@ -49,10 +49,19 @@ spec:
           description: DbUser is the Schema for the dbusers API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -60,17 +69,23 @@ spec:
               description: DbUserSpec defines the desired state of DbUser
               properties:
                 accessType:
-                  description: AccessType that should be given to a user Currently only readOnly and readWrite are supported by the operator
+                  description: |-
+                    AccessType that should be given to a user
+                    Currently only readOnly and readWrite are supported by the operator
                   type: string
                 cleanup:
                   type: boolean
                 credentials:
-                  description: 'Credentials should be used to setup everything relates to k8s secrets and configmaps TODO(@allanger): Field .spec.secretName should be moved here in the v1beta2 version'
+                  description: |-
+                    Credentials should be used to setup everything relates to k8s secrets and configmaps
+                    TODO(@allanger): Field .spec.secretName should be moved here in the v1beta2 version
                   properties:
                     templates:
-                      description: Templates to add custom entries to ConfigMaps and Secrets
+                      description: Templates to add custom entries to ConfigMaps and
+                        Secrets
                       items:
-                        description: Tempaltes to add custom entries to ConfigMaps and Secrets
+                        description: Tempaltes to add custom entries to ConfigMaps and
+                          Secrets
                         properties:
                           name:
                             type: string
@@ -86,7 +101,9 @@ spec:
                       type: array
                   type: object
                 databaseRef:
-                  description: DatabaseRef should contain a name of a Database to create a user there Database should be in the same namespace with the user
+                  description: |-
+                    DatabaseRef should contain a name of a Database to create a user there
+                    Database should be in the same namespace with the user
                   type: string
                 secretName:
                   description: SecretName name that should be used to save user's credentials


### PR DESCRIPTION
* Issue: https://github.com/db-operator/db-operator/issues/79

I had to add a namespace environment variable to allow db-operator to retrieve the namespace in which it runs in. Other than that I simply added a new field `version` to the `Database` CR.