### PR TITLE
Fix: Insufficient permissions on Cronjobs results in Database failing to turn healthy

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.36.0
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml
 # ---------------------------------------------------------------------------------
 kubeVersion: ">= 1.22-prerelease"
-appVersion: "2.12.1"
+appVersion: "2.12.2"
 description: The DB Operator creates databases and make them available in the cluster via Custom Resource.
 home: https://github.com/db-operator/db-operator
 maintainers:

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 type: application
 name: db-operator
-version: 1.36.0
+version: 1.36.1
 # ---------------------------------------------------------------------------------
 # -- All supported k8s versions are in the test:
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml
 # ---------------------------------------------------------------------------------
 kubeVersion: ">= 1.22-prerelease"
-appVersion: "2.12.2"
+appVersion: "2.12.1"
 description: The DB Operator creates databases and make them available in the cluster via Custom Resource.
 home: https://github.com/db-operator/db-operator
 maintainers:

--- a/charts/db-operator/templates/controller/rbac.yaml
+++ b/charts/db-operator/templates/controller/rbac.yaml
@@ -42,6 +42,13 @@ rules:
   - batch
   resources:
   - cronjobs
+  verbs:
+  - create
+  - update
+  - list
+- apiGroups:
+  - batch
+  resources:
   - jobs
   verbs:
   - create


### PR DESCRIPTION
Fixes issue https://github.com/db-operator/charts/issues/73

Db-operator throws error when trying to list cronjobs, due to missing list permission in the clusterrole.