### PR TITLE
Allow enabling user namespaces

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: db-operator
-version: 1.39.0
+version: 1.40.0
 # ---------------------------------------------------------------------------------
 # -- All supported k8s versions are in the test:
 # --  https://github.com/db-operator/charts/blob/main/.github/workflows/test.yaml

--- a/charts/db-operator/templates/controller/deployment.yaml
+++ b/charts/db-operator/templates/controller/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{ toYaml .Values.annotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "db-operator.serviceAccountName" . }}
       {{- end }}

--- a/charts/db-operator/templates/webhook/deployment.yaml
+++ b/charts/db-operator/templates/webhook/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         {{ toYaml .Values.annotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end }}
       {{- if .Values.webhook.serviceAccount.create }}
       serviceAccountName: {{ template "webhook.serviceAccountName" . }}
       {{- end }}

--- a/charts/db-operator/values.yaml
+++ b/charts/db-operator/values.yaml
@@ -77,6 +77,7 @@ securityContext:
     drop:
       - ALL
 
+hostUsers: true
 resources: {}
 nodeSelector: {}
 annotations: {}


### PR DESCRIPTION
This gates the `.spec.hostUsers` field behind a semver version check which verifies that a Kubernetes cluster is at least on version 1.33. If that is the case, it sets the field to `true` which disables user namespaces by default because cluster administrators need to prepare their cluster nodes first, before they are able to switch on user namespaces.

Fixes #78